### PR TITLE
Updated Travis-CI URL for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/heremaps/here-ios-sdk-examples.svg?branch=master)](https://travis-ci.org/heremaps/here-ios-sdk-examples)
+[![Build Status](https://travis-ci.com/heremaps/here-ios-sdk-examples.svg?branch=master)](https://travis-ci.com/heremaps/here-ios-sdk-examples)
 
 # HERE SDK for iOS example projects
 


### PR DESCRIPTION
The travis-CI has moved from travis-ci.org to travis-ci.com